### PR TITLE
Reject blank note fields

### DIFF
--- a/src/app/api/models.py
+++ b/src/app/api/models.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel, Field, ConfigDict, EmailStr
+from pydantic import BaseModel, Field, ConfigDict, EmailStr, StringConstraints
 from datetime import datetime
-from typing import Optional, List
+from typing import Annotated, Optional, List
 
 
 class UserBase(BaseModel):
@@ -32,10 +32,14 @@ class TokenData(BaseModel):
 class NoteBase(BaseModel):
     """Base model for note creation and updates"""
 
-    title: str = Field(..., min_length=3, max_length=255, description="Note title")
-    description: str = Field(
-        ..., min_length=3, max_length=1000, description="Note description"
-    )
+    title: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, min_length=3, max_length=255),
+    ] = Field(..., description="Note title")
+    description: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, min_length=3, max_length=1000),
+    ] = Field(..., description="Note description")
     completed: bool = Field(default=False, description="Completion status")
     tags: List[str] = Field(default_factory=list, description="List of note tags")
 

--- a/src/tests/test_notes.py
+++ b/src/tests/test_notes.py
@@ -58,6 +58,8 @@ class TestCreateNote:
             ),  # Valid
             ({"title": "1", "description": "bar"}, 422),  # Title too short
             ({"title": "foo", "description": "1"}, 422),  # Description too short
+            ({"title": "   ", "description": "bar"}, 422),  # Blank title
+            ({"title": "foo", "description": "   "}, 422),  # Blank description
             ({"title": "x" * 256, "description": "bar"}, 422),  # Title too long
             ({"title": "foo", "description": "x" * 1001}, 422),  # Description too long
         ],
@@ -352,6 +354,8 @@ class TestUpdateNote:
             (999, {"title": "foo", "description": "bar"}, 404),  # Not found
             (1, {"title": "1", "description": "bar"}, 422),  # Title too short
             (1, {"title": "foo", "description": "1"}, 422),  # Description too short
+            (1, {"title": "   ", "description": "bar"}, 422),  # Blank title
+            (1, {"title": "foo", "description": "   "}, 422),  # Blank description
             (0, {"title": "foo", "description": "bar"}, 422),  # Invalid ID
         ],
     )


### PR DESCRIPTION
## Summary
- strip note title and description values before length validation
- reject whitespace-only title and description payloads on create and update
- add regression cases for blank note fields

## Validation
- targeted note API test suite passed with pinned app requirements plus pytest 9.0.3
